### PR TITLE
Small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### Install
 
 To get started, simply [download the console from
-releases](https://github.com/discordconsole-team/DiscordConsole/releases), r compile it yourself: `go get
+releases](https://github.com/discordconsole-team/DiscordConsole/releases), or compile it yourself: `go get
 github.com/discordconsole-team/DiscordConsole`
 
 ### Usage


### PR DESCRIPTION
Minor Type in README.
> download the console from releases, `r` compile it yourself --> download the console from releases, **`or`** compile it yourself